### PR TITLE
Fixing issues with Mediathek Direkt for Kodi

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -23,7 +23,7 @@ maxFileAge = maxFileAge*60
 showTopicsDirectly = str(addon.getSetting("showTopicsDirectly")).lower()
 hideAD = str(addon.getSetting("hideAD")).lower()
 playBestQuality = str(addon.getSetting("playBestQuality")).lower()
-updateURL = 'http://www.mediathekdirekt.de/good.json'
+updateURL = 'https://www.mediathekdirekt.de/good.json'
 
 if not os.path.isdir(addon_work_folder):
     os.mkdir(addon_work_folder)

--- a/addon.py
+++ b/addon.py
@@ -500,9 +500,14 @@ def getData():
         if now-fileTime > maxFileAge:
             updateData()
 
-    with open(jsonFile, 'r') as f:
-        data = json.load(f)
-        return data
+    try:
+        with open(jsonFile, 'r') as f:
+            data = json.load(f)
+            return data
+    except IOError as ioerr:
+        dialog = xbmcgui.Dialog()
+        dialog.notification('Error reading database', str(ioerr), xbmcgui.NOTIFICATION_ERROR, 20000)
+        exit(1)
 
 def getFanart(channel):
     channel = channel.replace(' ', "").lower()

--- a/addon.py
+++ b/addon.py
@@ -23,6 +23,7 @@ maxFileAge = maxFileAge*60
 showTopicsDirectly = str(addon.getSetting("showTopicsDirectly")).lower()
 hideAD = str(addon.getSetting("hideAD")).lower()
 playBestQuality = str(addon.getSetting("playBestQuality")).lower()
+updateURL = 'http://www.mediathekdirekt.de/good.json'
 
 if not os.path.isdir(addon_work_folder):
     os.mkdir(addon_work_folder)
@@ -443,7 +444,12 @@ def searchDate(channelDate = ""):
 
 def updateData():
     target = urllib.URLopener()
-    target.retrieve("http://www.mediathekdirekt.de/good.json", jsonFile)
+    try:
+        target.retrieve(updateURL, jsonFile)
+    except IOError as ioerr:
+        dialog = xbmcgui.Dialog()
+        dialog.notification('Error updating database', str(ioerr) + ' Update-URL: ' + updateURL, xbmcgui.NOTIFICATION_ERROR, 30000)
+        exit(1)
 
 def getBestQuality(video_url):
     if playBestQuality == "true":


### PR DESCRIPTION
Hi there,

I recently had a lot of issues with the Kodi addon "Mediathek Direkt". It crashed right upon opening. In the log file I found stuff like this:

`18:39:53.910 T:140254001211136   ERROR: EXCEPTION Thrown (PythonToCppException) : -->Python callback/script returned the following error<--
                                             - NOTE: IGNORING THIS CAN LEAD TO MEMORY LEAKS!
                                            Error Type: <type 'exceptions.IOError'>
                                            Error Contents: ('http error', 301, 'Moved Permanently', <httplib.HTTPMessage instance at 0x7f8f4e1fb5a8>)
                                            Traceback (most recent call last):
                                              File "/storage/.kodi/addons/plugin.video.mediathekdirekt/addon.py", line 569, in <module>
                                                updateData()
                                              File "/storage/.kodi/addons/plugin.video.mediathekdirekt/addon.py", line 446, in updateData
                                                target.retrieve("http://www.mediathekdirekt.de/good.json", jsonFile)
                                              File "/usr/lib/python2.7/urllib.py", line 245, in retrieve
                                                fp = self.open(url, data)
                                              File "/usr/lib/python2.7/urllib.py", line 213, in open
                                                return getattr(self, name)(url)
                                              File "/usr/lib/python2.7/urllib.py", line 364, in open_http
                                                return self.http_error(url, fp, errcode, errmsg, headers)
                                              File "/usr/lib/python2.7/urllib.py", line 381, in http_error
                                                return self.http_error_default(url, fp, errcode, errmsg, headers)
                                              File "/usr/lib/python2.7/urllib.py", line 386, in http_error_default
                                                raise IOError, ('http error', errcode, errmsg, headers)
                                            IOError: ('http error', 301, 'Moved Permanently', <httplib.HTTPMessage instance at 0x7f8f4e1fb5a8>)
                                            -->End of Python script error report<--`

The main issue is, that the source website switched to https, so the URL has to be changed. I also fixed two errors in error-handling.
It would be nice, if you could merge these changes into your own development branch, so others could profit from them as well.

Greetings

Hase Harald