### PR TITLE
Added gunzip support for good.json

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -7,6 +7,8 @@ import urllib
 import json
 import re
 import time
+import gzip
+import shutil
 from datetime import date, timedelta
 
 addonID = 'plugin.video.mediathekdirekt'
@@ -442,8 +444,12 @@ def searchDate(channelDate = ""):
     endOfDirectory()
 
 def updateData():
+    jsonFileGz = jsonFile + '.gz'
     target = urllib.URLopener()
-    target.retrieve("https://www.mediathekdirekt.de/good.json", jsonFile)
+    target.retrieve("https://www.mediathekdirekt.de/good.json", jsonFileGz)
+    with gzip.open(jsonFileGz, 'rb') as f_in:
+        with open(jsonFile, 'wb') as f_out:
+            shutil.copyfileobj(f_in, f_out)
 
 def getBestQuality(video_url):
     if playBestQuality == "true":


### PR DESCRIPTION
Since some days plugin.video.mediathekdirekt doesn't start anymore (have a look at https://www.kodinerds.net/index.php/Thread/53682-RELEASE-Mediathek-Direkt/?pageNo=6). Logfile talks about an "NO JSON object could be decoded" when consuming good.json file. Having a look at this file shows me an gziped file so deserialisation must fail.
My commit changes addon to store download as good.json.gz and gunzip it to good.json in a second step. Maybe there is another way to do this with urllib during download, I'm not the python geek ;-)
To take changes affect, you have to manualy delete an existing good.json file in your profiles directory! 